### PR TITLE
lint: Removed duplicate linting message

### DIFF
--- a/src/cfengine_cli/lint.py
+++ b/src/cfengine_cli/lint.py
@@ -162,7 +162,6 @@ def _walk(filename, lines, node) -> int:
 def lint_policy_file(
     filename, original_filename=None, original_line=None, snippet=None, prefix=None
 ):
-    print(f"Linting: {filename}")
     assert original_filename is None or type(original_filename) is str
     assert original_line is None or type(original_line) is int
     assert snippet is None or type(snippet) is int


### PR DESCRIPTION
This became a bit too spammy. Each file already has at least one PASS / FAIL
print, should be enough.