### PR TITLE
cfengine format: Fixed indentation of comments inside empty bundles and ensured empty lines between bundles were empty comments were removed

### DIFF
--- a/src/cfengine_cli/format.py
+++ b/src/cfengine_cli/format.py
@@ -25,6 +25,8 @@ CLASS_GUARD_TYPES = {
 
 BLOCK_TYPES = {"bundle_block", "promise_block", "body_block"}
 
+BLOCK_BODY_TYPES = {"bundle_block_body", "promise_block_body", "body_block_body"}
+
 PROMISER_PARTS = {"promiser", "->", "stakeholder"}
 
 
@@ -642,6 +644,10 @@ def _comment_indent(node: Node, indent: int) -> int:
     if nearest is None:
         nearest = _skip_comments(node.prev_named_sibling, "prev")
     if nearest and nearest.type in INDENTED_TYPES:
+        return indent + 2
+    # No indented sibling found — if we're directly inside a block body,
+    # indent so the comment lines up with where promises/attributes would.
+    if nearest is None and node.parent and node.parent.type in BLOCK_BODY_TYPES:
         return indent + 2
     return indent
 

--- a/src/cfengine_cli/format.py
+++ b/src/cfengine_cli/format.py
@@ -561,6 +561,9 @@ def _format_block_header(node: Node, fmt: Formatter) -> list[Node]:
     line = " ".join(header_parts)
     if not fmt.empty:
         prev_sib = node.prev_named_sibling
+        # Skip over preceding empty comments since they will be removed
+        while prev_sib and prev_sib.type == "comment" and _is_empty_comment(prev_sib):
+            prev_sib = prev_sib.prev_named_sibling
         if not (prev_sib and prev_sib.type == "comment"):
             fmt.blank_line()
     fmt.print(line, 0)

--- a/tests/format/005_bundle_comments.expected.cf
+++ b/tests/format/005_bundle_comments.expected.cf
@@ -47,3 +47,8 @@ bundle agent f(s, d, o, p)
   reports:
     "Hello, world!";
 }
+
+bundle agent g
+{
+  # comment
+}

--- a/tests/format/005_bundle_comments.input.cf
+++ b/tests/format/005_bundle_comments.input.cf
@@ -45,3 +45,8 @@ bundle agent f(
   reports:
     "Hello, world!";
 }
+#
+bundle agent g
+{
+  # comment
+}


### PR DESCRIPTION
- **tests: Added formatting test for leaving empty line when removing empty comment(s)**
- **cfengine format: Fixed indentation of comments inside empty blocks**
- **cfengine format: Fixed case where removed empty comments would cause no empty line between bundles**
