### PR TITLE
cfengine format: Removed extra empty lines around macros

### DIFF
--- a/src/cfengine_cli/format.py
+++ b/src/cfengine_cli/format.py
@@ -606,6 +606,9 @@ def _needs_blank_line_before(child: Node, indent: int, line_length: int) -> bool
         return prev.type == "bundle_section"
 
     if child.type == "promise":
+        # An @if macro already provides visual separation
+        if prev.type == "macro" and text(prev).startswith("@if"):
+            return False
         # Skip past macros to find the content-bearing previous sibling,
         # so we detect promise groups separated by macro-split halves.
         prev_content = prev

--- a/tests/format/011_macros.expected.cf
+++ b/tests/format/011_macros.expected.cf
@@ -83,3 +83,29 @@ bundle agent half_with_comment
       string => "old_value";
 @endif
 }
+
+bundle common cfe_internal_inputs
+# @brief Include internal self management policies
+{
+  vars:
+    enterprise_edition.(policy_server|am_policy_hub)::
+      "input[enterprise_hub_specific]"
+        string => "cfe_internal/enterprise/CFE_hub_specific.cf",
+        comment => "Lorem ipsum.";
+@if minimum_version(3.12.0)
+      "input[enterprise_hub_federation]"
+        string => "cfe_internal/enterprise/federation/federation.cf",
+        comment => "Lorem ipsum.";
+@endif
+    enterprise_edition::
+      "input[enterprise_knowledge]"
+        string => "cfe_internal/enterprise/CFE_knowledge.cf",
+        comment => "Lorem ipsum.";
+
+      "input[enterprise_main]"
+        string => "cfe_internal/enterprise/main.cf",
+        comment => "Lorem ipsum.";
+
+    any::
+      "inputs" slist => getvalues("input");
+}

--- a/tests/format/011_macros.input.cf
+++ b/tests/format/011_macros.input.cf
@@ -82,3 +82,26 @@ string => "new_value";
 string => "old_value";
 @endif
 }
+bundle common cfe_internal_inputs
+# @brief Include internal self management policies
+{
+vars:
+enterprise_edition.(policy_server|am_policy_hub)::
+"input[enterprise_hub_specific]"
+string => "cfe_internal/enterprise/CFE_hub_specific.cf",
+comment => "Lorem ipsum.";
+@if minimum_version(3.12.0)
+"input[enterprise_hub_federation]"
+string => "cfe_internal/enterprise/federation/federation.cf",
+comment => "Lorem ipsum.";
+@endif
+enterprise_edition::
+"input[enterprise_knowledge]"
+string => "cfe_internal/enterprise/CFE_knowledge.cf",
+comment => "Lorem ipsum.";
+"input[enterprise_main]"
+string => "cfe_internal/enterprise/main.cf",
+comment => "Lorem ipsum.";
+any::
+"inputs" slist => getvalues("input");
+}


### PR DESCRIPTION
- **Added one more test case from promises.cf to macro formatting test**
- **cfengine format: Removed extra empty lines around macros**
