### PR TITLE
Fixed skipping of files and folders in lint and format

### DIFF
--- a/src/cfengine_cli/commands.py
+++ b/src/cfengine_cli/commands.py
@@ -68,6 +68,8 @@ def _format_dirname(directory: str, line_length: int, check: bool) -> int:
     for filename in find(directory, extension=".json"):
         ret |= _format_filename(filename, line_length, check)
     for filename in find(directory, extension=".cf"):
+        if filename.endswith(".x.cf"):
+            continue
         ret |= _format_filename(filename, line_length, check)
     return ret
 

--- a/src/cfengine_cli/commands.py
+++ b/src/cfengine_cli/commands.py
@@ -14,7 +14,6 @@ from cfengine_cli.format import (
     format_policy_fin_fout,
 )
 from cfengine_cli.utils import UserError
-from cfbs.utils import find
 from cfbs.commands import build_command
 from cf_remote.commands import deploy as deploy_command
 
@@ -54,8 +53,6 @@ def _format_filename(filename: str, line_length: int, check: bool) -> int:
     """Format a single file.
 
     Raises PolicySyntaxError for .cf files with syntax errors."""
-    if filename.startswith("./."):
-        return 0
     if filename.endswith(".json"):
         return format_json_file(filename, check)
     if filename.endswith(".cf"):
@@ -65,12 +62,17 @@ def _format_filename(filename: str, line_length: int, check: bool) -> int:
 
 def _format_dirname(directory: str, line_length: int, check: bool) -> int:
     ret = 0
-    for filename in find(directory, extension=".json"):
-        ret |= _format_filename(filename, line_length, check)
-    for filename in find(directory, extension=".cf"):
-        if filename.endswith(".x.cf"):
-            continue
-        ret |= _format_filename(filename, line_length, check)
+    for root, dirs, files in os.walk(directory):
+        # Don't recurse into hidden folders
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for name in sorted(files):
+            if name.startswith("."):
+                continue  # Hidden files are ignored by default
+            if name.endswith(".x.cf"):
+                continue  # Policy files with intentional mistakes
+            filepath = os.path.join(root, name)
+            if name.endswith(".json") or name.endswith(".cf"):
+                ret |= _format_filename(filepath, line_length, check)
     return ret
 
 

--- a/src/cfengine_cli/lint.py
+++ b/src/cfengine_cli/lint.py
@@ -816,6 +816,8 @@ def _find_filenames_in_arg_folder(arg: str) -> list[str]:
     for root, dirs, files in os.walk(arg, followlinks=True):
         # Remove hidden files:
         files = [f for f in files if not f[0] == "."]
+        # Skip .x.cf files (policy files with intentional errors):
+        files = [f for f in files if not f.endswith(".x.cf")]
         for name in files:
             if name.endswith(LINT_EXTENSIONS):
                 results.append(os.path.join(root, name))


### PR DESCRIPTION
For both lint and format we want similar behavior:
- Skip hidden files (files starting with .) - don't lint / format them.
- Skip policy files with intentional errors (ending with .x.cf) - don't lint / format them.
- Skip hidden folders (folders starting with .) - don't recurse into them.

In all cases, this should only affect the code where we recurse into folders and find files. If the user explicitly specifies a `.x.cf` file as an argument, we should not skip it. Same for hidden files and folders.