### PR TITLE
cfengine lint: Include .cf.sub files

### DIFF
--- a/src/cfengine_cli/lint.py
+++ b/src/cfengine_cli/lint.py
@@ -40,7 +40,7 @@ from cfbs.cfbs_config import CFBSConfig
 from cfbs.utils import find
 from cfengine_cli.utils import UserError
 
-LINT_EXTENSIONS = (".cf", ".json")
+LINT_EXTENSIONS = (".cf", ".cf.sub", ".json")
 DEFAULT_NAMESPACE = "default"
 VARS_TYPES = {
     "data",
@@ -1012,7 +1012,7 @@ def _lint_main(
         if filename.endswith(".json"):
             errors += _lint_json_selector(filename)
             continue
-        assert filename.endswith(".cf")
+        assert filename.endswith((".cf", ".cf.sub"))
         policy_file = PolicyFile(filename, snippet)
         r = _check_syntax(policy_file, state)
         errors += r


### PR DESCRIPTION
Among all the policy files in core and masterfiles, there are
several .cf.sub files. We want to include these for linting.
They (should) contain valid policy, and sometimes they contain
body / bundle definitions used in other policy files.

Eventually, we might choose to rename all of them to .sub.cf
for a more "correct" file extension.