### PR TITLE
Updated tree-sitter-cfengine dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cf-remote>=0.7.3",
     "cfbs>=5.5.0",
-    "tree-sitter-cfengine>=1.1.11",
+    "tree-sitter-cfengine>=1.1.12",
     "tree-sitter>=0.25",
     "markdown-it-py>=3.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ requires-dist = [
     { name = "cfbs", specifier = ">=5.5.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "tree-sitter", specifier = ">=0.25" },
-    { name = "tree-sitter-cfengine", specifier = ">=1.1.11" },
+    { name = "tree-sitter-cfengine", specifier = ">=1.1.12" },
 ]
 
 [package.metadata.requires-dev]
@@ -441,18 +441,18 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-cfengine"
-version = "1.1.11"
+version = "1.1.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/86/a9507198ac34c8ed2abbd340200546c4f1b05da1db455c8a79713c072709/tree_sitter_cfengine-1.1.11.tar.gz", hash = "sha256:03d335c8ba549859e0e96a454949f246800e85d200c0ac9561af8c4b3b773b76", size = 16744, upload-time = "2026-04-30T21:57:31.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/82/6c587bacd4983ceb767afb8f38c99a281e09f1ad0bc8128ecf3d0000535d/tree_sitter_cfengine-1.1.12.tar.gz", hash = "sha256:98a0524acb41988a18dce91f915c61248e979dfe227ee86e45bf81f00816dde2", size = 16847, upload-time = "2026-05-04T14:20:49.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/63/3d0bd0cf595b59131e18087be89381f64f3d17e5ddcaf93c3e36cdabdd1b/tree_sitter_cfengine-1.1.11-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bcb878977f5d6d09768cb5e69b293b1f47dadfe50155724d0032deddf92f76c9", size = 12973, upload-time = "2026-04-30T21:57:24.95Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/2d/76a80aabfe18e27b7cc3e80946b3c7b0a60f2f65deb3ba81d5df8392c7b2/tree_sitter_cfengine-1.1.11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e2568a43dabafdceb7d2eb8277f380898fa6f2cfc5118a8f6fffa8e999158bd2", size = 13567, upload-time = "2026-04-30T21:57:25.78Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/db/8743511c594a01e325711ef2e8fb6324d32b7c7a9c5c9f7a2a146b8f72fa/tree_sitter_cfengine-1.1.11-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e36cdc08ea1b37f39e4061fa8261ffd7e46144b16a0f6fe02b4b27dfb1aee33d", size = 24023, upload-time = "2026-04-30T21:57:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/91/0d/3c176aaf2028dbe47024fb0cc6009a3349976ceff06a969593b2925cb45b/tree_sitter_cfengine-1.1.11-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70ccdeb54db00a51f1501ac4d49583c53d9530f8bd6eaa5ffa5fd386d5db3c4c", size = 26415, upload-time = "2026-04-30T21:57:27.366Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/84/0023af45bc76d654e51e3a538120dc30284f6dfd78cbefd9d72366aaca91/tree_sitter_cfengine-1.1.11-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:505d3f6a7c683bbbe650b2a259cce2dfbd6d1d5d602da4d0077ce0de0cbb9188", size = 25543, upload-time = "2026-04-30T21:57:28.025Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/eb/20b4bfd677e6831ad4cdef6cb0ca494fdae546e86ab253a361e6277df2c7/tree_sitter_cfengine-1.1.11-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:97bcacccca21bd15db9a4e87a31e55aab5c1755d3c1d90f9304ac40d5d256a02", size = 23781, upload-time = "2026-04-30T21:57:28.788Z" },
-    { url = "https://files.pythonhosted.org/packages/51/c1/44df84907633eb1ed12228268b785b0da98483e2b0314b7d1a4efcbf545c/tree_sitter_cfengine-1.1.11-cp39-abi3-win_amd64.whl", hash = "sha256:37e16ee62cf4b38d86263cb6306313cf0d5542902e4ad770194e08af58e120a5", size = 15974, upload-time = "2026-04-30T21:57:29.831Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/88/c2c9e36e560d1c2494ba8afe3c51aa7df574bd3e5391dacdf4904aa0abe6/tree_sitter_cfengine-1.1.11-cp39-abi3-win_arm64.whl", hash = "sha256:80e82b9659b74f49095b4f26e256b58953da86dfbf586998f9972a852ee59c16", size = 14798, upload-time = "2026-04-30T21:57:30.565Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cf/ebd9d6c01251c7072ddb2c5ddedc012984cd058bdcdd5c7d523ab0463a9f/tree_sitter_cfengine-1.1.12-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:439a686b5c42059b215460d9f00b403a18cf8885230616db6245c5316a17a291", size = 13018, upload-time = "2026-05-04T14:20:41.868Z" },
+    { url = "https://files.pythonhosted.org/packages/71/34/ee8e71c7b055a6c72d0426193407a95fa266f76b72b44ef74e2e87b672be/tree_sitter_cfengine-1.1.12-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7d8e251ab24f5fec347d32c4aa469f76354060625d2b1d977daa525a60f22d0d", size = 13623, upload-time = "2026-05-04T14:20:43.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b2/4dd66177c89863e88806fbd1d3fd90f049c415e2ff0d514290a14e21b7f1/tree_sitter_cfengine-1.1.12-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c63ddb5ca3e493a3ebc2e4ff6a3d0f881ec4455ca465bee274ebf2df409e2d1", size = 24079, upload-time = "2026-05-04T14:20:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f6/3a333a3642fc361245ae759ce5cd47ad2b1794ae8f3b5495447b6c6abbc6/tree_sitter_cfengine-1.1.12-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ee214229b47943d040e1f417c1e90fba13b0cde42447dab9ea8e5b8fa835e6d", size = 26488, upload-time = "2026-05-04T14:20:44.878Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b2/129a14ea4df6dd6d2ca916dd374c35456cc6fbd93356cdc9d3ccd707810b/tree_sitter_cfengine-1.1.12-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3d0f1552d3ae3ac0926b214a2f7d3d3ab1b7cbc80d8c2e0188cd088d50de1677", size = 25609, upload-time = "2026-05-04T14:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/04/4ca7634e95bd165ed4390595d38bd8ca0fd773b62fdc81fff0133fab39aa/tree_sitter_cfengine-1.1.12-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1bf058a38376ab0673ec13faa8cbd9e83e062b7cab633cddd4a2ebca59f2598e", size = 23851, upload-time = "2026-05-04T14:20:46.37Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f5/afa98aa454a0cf0ea9215c0f853fdbbb332ee627582b1f979747ed14b850/tree_sitter_cfengine-1.1.12-cp39-abi3-win_amd64.whl", hash = "sha256:f6fc2b06fb9484c6775e21171d162e21dec1645ad3e9be6a389294e108b75f4b", size = 16029, upload-time = "2026-05-04T14:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ba/a2cff11544e136d78a5f2a62edac9ed7fc3e77a51d8c712a61882b606c1a/tree_sitter_cfengine-1.1.12-cp39-abi3-win_arm64.whl", hash = "sha256:1d883df6aaae4882080c247cbc0f2b756f94bf731ca9886d1573931561251dc8", size = 14849, upload-time = "2026-05-04T14:20:47.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This brings new grammer for multiple repeating square brackets after an identifier.