### PR TITLE
Revert "Renovate: Try with . as repo"

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -6,5 +6,5 @@ module.exports = {
   onboarding: false,
   requireConfig: "optional",
   branchPrefix: "renovate/",
-  repositories: ["."],
+  repositories: ["cfengine/cfengine-cli"],
 };


### PR DESCRIPTION
Reverts cfengine/cfengine-cli#182

This change was wrong, it was correct before. The problem seems to have been the permissions for the token I was using.