### PR TITLE
Update GitHub Actions workflow to include persist-credentials

### DIFF
--- a/.github/workflows/update-syntax-description.yml
+++ b/.github/workflows/update-syntax-description.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: "main"
+          persist-credentials: false # prevents duplicate Authorization header error with create-pull-request
       - name: Set up Python 3.12
         uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
Added persist-credentials option to prevent duplicate Authorization header error.