### PR TITLE
Fixed typo in `cfengine --help`

### DIFF
--- a/src/cfengine_cli/cfengine_wrapper/arg_parse.py
+++ b/src/cfengine_cli/cfengine_wrapper/arg_parse.py
@@ -35,10 +35,16 @@ def parse_wrapper_args(subp: argparse._SubParsersAction):
         default=None,
     )
 
-    subp.add_parser("build", help="Build a policy set from a CFEngine Build project\n\
-A wrapper arount the cfbs `build`-function.")
-    sp = subp.add_parser("deploy", help="Deploy policy-set (masterfiles) to hub\n\
-A wrapper around the cf-remote `deploy`-function with some added niceties.")
+    subp.add_parser(
+        "build",
+        help="""Build a policy set from a CFEngine Build project.
+A wrapper around the cfbs `build`-function.""",
+    )
+    sp = subp.add_parser(
+        "deploy",
+        help="""Deploy policy-set (masterfiles) to hub.
+A wrapper around the cf-remote `deploy`-function with some added niceties.""",
+    )
     sp.add_argument("--hub", help="Hub(s) to deploy to", type=str)
     sp.add_argument(
         "masterfiles",


### PR DESCRIPTION
Before:
```
$ cfengine --help | grep -A1 'Build a policy set from a'
    build               Build a policy set from a CFEngine Build project A
                        wrapper arount the cfbs `build`-function
```
After:
```
$ cfengine --help | grep -A1 'Build a policy set from a'
    build               Build a policy set from a CFEngine Build project. A
                        wrapper around the cfbs `build`-function.
```